### PR TITLE
Multiline Literals

### DIFF
--- a/scanner/rune-buffer.go
+++ b/scanner/rune-buffer.go
@@ -1,0 +1,38 @@
+package scanner
+
+const bufferSize = 3
+
+func appendRuneToBuffer(r rune, buf []rune) []rune {
+	buf = append(buf, r)
+	if len(buf) > bufferSize {
+		buf = buf[1:]
+	}
+
+	return buf
+}
+
+func containsOnlyRune(r rune, buf []rune) bool {
+	for _, bufRune := range buf {
+		if bufRune != r {
+			return false
+		}
+	}
+
+	return true
+}
+
+func bufferContainsLiterals(buf []rune) bool {
+	if len(buf) != bufferSize {
+		return false
+	}
+
+	return containsOnlyRune(runeQuotation, buf) || containsOnlyRune(runeApostrophe, buf) // " '
+}
+
+func escapedCharacter(buf []rune) bool {
+	if len(buf) < 2 {
+		return false
+	}
+
+	return buf[len(buf)-2] == runeBackslash
+}

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -15,12 +15,12 @@ var scanTestCases = map[string]struct {
 }{
 	"spiderman compact": {
 		data: []byte(`<http://example.org/green-goblin>
-		<http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/spiderman> ;
-		<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> ;
-		<http://xmlns.com/foaf/0.1/name> "Green Goblin".<http://example.org/spiderman>
-		<http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/green-goblin>;
-		<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person>;
-		<http://xmlns.com/foaf/0.1/name> "Spiderman", "Человек-паук" .`),
+				<http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/spiderman> ;
+				<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> ;
+				<http://xmlns.com/foaf/0.1/name> "Green Goblin".<http://example.org/spiderman>
+				<http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/green-goblin>;
+				<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person>;
+				<http://xmlns.com/foaf/0.1/name> "Spiderman", "Человек-паук" .`),
 		expectedTokens: []string{
 			"<http://example.org/green-goblin>",
 			"<http://www.perceive.net/schemas/relationship/enemyOf>",
@@ -57,9 +57,9 @@ var scanTestCases = map[string]struct {
 	},
 	"ignore_comments": {
 		data: []byte(`<http://example.org/green-goblin>
-		<http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/spiderman> ;
-		<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> ; # this is a comment
-		<http://xmlns.com/foaf/0.1/name> "Green Goblin".`),
+				<http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/spiderman> ;
+				<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> ; # this is a comment
+				<http://xmlns.com/foaf/0.1/name> "Green Goblin".`),
 		expectedTokens: []string{
 			"<http://example.org/green-goblin>",
 			"<http://www.perceive.net/schemas/relationship/enemyOf>",
@@ -80,9 +80,9 @@ var scanTestCases = map[string]struct {
 	},
 	"ignore_label": {
 		data: []byte(`<http://example.org/green-goblin>
-		<http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/spiderman> ;
-		<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> ;
-		<http://xmlns.com/foaf/0.1/name> "Green Goblin"@en .`),
+				<http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/spiderman> ;
+				<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> ;
+				<http://xmlns.com/foaf/0.1/name> "Green Goblin"@en .`),
 		expectedTokens: []string{
 			"<http://example.org/green-goblin>",
 			"<http://www.perceive.net/schemas/relationship/enemyOf>",
@@ -103,9 +103,9 @@ var scanTestCases = map[string]struct {
 	},
 	"ignore_prefixed_datatype": {
 		data: []byte(`<http://example.org/green-goblin>
-		<http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/spiderman> ;
-		<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> ;
-		<http://xmlns.com/foaf/0.1/name> "Green Goblin"^^xsd:string .`),
+				<http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/spiderman> ;
+				<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> ;
+				<http://xmlns.com/foaf/0.1/name> "Green Goblin"^^xsd:string .`),
 		expectedTokens: []string{
 			"<http://example.org/green-goblin>",
 			"<http://www.perceive.net/schemas/relationship/enemyOf>",
@@ -126,8 +126,8 @@ var scanTestCases = map[string]struct {
 	},
 	"booleans": {
 		data: []byte(`@prefix s: <http://example.org/stats/> .
-		<http://somecountry.example/census2007>
-			s:isLandlocked false .`),
+				<http://somecountry.example/census2007>
+					s:isLandlocked false .`),
 		expectedTokens: []string{
 			"@prefix",
 			"s:",
@@ -144,8 +144,8 @@ var scanTestCases = map[string]struct {
 	},
 	"empty_prefix": {
 		data: []byte(`@prefix : <http://example.org/stats/> .
-		<http://somecountry.example/census2007>
-			:isLandlocked false .`),
+				<http://somecountry.example/census2007>
+					:isLandlocked false .`),
 		expectedTokens: []string{
 			"@prefix",
 			":",
@@ -162,8 +162,8 @@ var scanTestCases = map[string]struct {
 	},
 	"prefix_no_ending_slash": {
 		data: []byte(`@prefix : <http://example.org/stats> .
-		<http://somecountry.example/census2007>
-			:isLandlocked false .`),
+				<http://somecountry.example/census2007>
+					:isLandlocked false .`),
 		expectedTokens: []string{
 			"@prefix",
 			":",
@@ -180,8 +180,8 @@ var scanTestCases = map[string]struct {
 	},
 	"base_no_ending_slash": {
 		data: []byte(`@base <http://example.org/stats> .
-		<http://somecountry.example/census2007>
-			<#isLandlocked> false .`),
+				<http://somecountry.example/census2007>
+					<#isLandlocked> false .`),
 		expectedTokens: []string{
 			"@base",
 			"<http://example.org/stats>",
@@ -197,9 +197,9 @@ var scanTestCases = map[string]struct {
 	},
 	"ignore_datatype": {
 		data: []byte(`<http://example.org/green-goblin>
-		<http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/spiderman> ;
-		<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> ;
-		<http://xmlns.com/foaf/0.1/name> "Green Goblin"^^<http://www.w3.org/2001/XMLSchema#string> .`),
+				<http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/spiderman> ;
+				<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> ;
+				<http://xmlns.com/foaf/0.1/name> "Green Goblin"^^<http://www.w3.org/2001/XMLSchema#string> .`),
 		expectedTokens: []string{
 			"<http://example.org/green-goblin>",
 			"<http://www.perceive.net/schemas/relationship/enemyOf>",
@@ -220,12 +220,12 @@ var scanTestCases = map[string]struct {
 	},
 	"read_prefix": {
 		data: []byte(`@prefix foaf: <http://xmlns.com/foaf/0.1/> .
-		@prefix rel: <http://www.perceive.net/schemas/relationship/> .
+				@prefix rel: <http://www.perceive.net/schemas/relationship/> .
 
-		<http://example.org/green-goblin>
-			rel:enemyOf <http://example.org/spiderman> ;
-			<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> foaf:Person ;
-			foaf:name "Green Goblin".`),
+				<http://example.org/green-goblin>
+					rel:enemyOf <http://example.org/spiderman> ;
+					<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> foaf:Person ;
+					foaf:name "Green Goblin".`),
 		expectedTokens: []string{
 			"@prefix",
 			"foaf:",
@@ -254,13 +254,13 @@ var scanTestCases = map[string]struct {
 	},
 	"read_prefix_and_base": {
 		data: []byte(`@base <http://example.org/> .
-		@prefix foaf: <http://xmlns.com/foaf/0.1/> .
-		@prefix rel: <http://www.perceive.net/schemas/relationship/> .
+				@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+				@prefix rel: <http://www.perceive.net/schemas/relationship/> .
 
-		<#green-goblin>
-			rel:enemyOf <#spiderman> ;
-			<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> foaf:Person ;
-			foaf:name "Green Goblin".`),
+				<#green-goblin>
+					rel:enemyOf <#spiderman> ;
+					<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> foaf:Person ;
+					foaf:name "Green Goblin".`),
 		expectedTokens: []string{
 			"@base",
 			"<http://example.org/>",
@@ -292,12 +292,12 @@ var scanTestCases = map[string]struct {
 	},
 	"spiderman n-triples": {
 		data: []byte(`<http://example.org/green-goblin> <http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/spiderman> .
-		<http://example.org/green-goblin> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
-		<http://example.org/green-goblin> <http://xmlns.com/foaf/0.1/name> "Green Goblin".
-		<http://example.org/spiderman> <http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/green-goblin> .
-		<http://example.org/spiderman> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
-		<http://example.org/spiderman> <http://xmlns.com/foaf/0.1/name> "Spiderman" .
-		<http://example.org/spiderman> <http://xmlns.com/foaf/0.1/name> "Человек-паук" .`),
+				<http://example.org/green-goblin> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
+				<http://example.org/green-goblin> <http://xmlns.com/foaf/0.1/name> "Green Goblin".
+				<http://example.org/spiderman> <http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/green-goblin> .
+				<http://example.org/spiderman> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
+				<http://example.org/spiderman> <http://xmlns.com/foaf/0.1/name> "Spiderman" .
+				<http://example.org/spiderman> <http://xmlns.com/foaf/0.1/name> "Человек-паук" .`),
 		expectedTokens: []string{
 			"<http://example.org/green-goblin>",
 			"<http://www.perceive.net/schemas/relationship/enemyOf>",
@@ -340,12 +340,12 @@ var scanTestCases = map[string]struct {
 	},
 	"read_rdf_type_shorthand": {
 		data: []byte(`@prefix foaf: <http://xmlns.com/foaf/0.1/> .
-		@prefix rel: <http://www.perceive.net/schemas/relationship/> .
-		
-		<http://example.org/green-goblin>
-			rel:enemyOf <http://example.org/spiderman> ;
-			a foaf:Person ;
-			foaf:name "Green Goblin".`),
+				@prefix rel: <http://www.perceive.net/schemas/relationship/> .
+
+				<http://example.org/green-goblin>
+					rel:enemyOf <http://example.org/spiderman> ;
+					a foaf:Person ;
+					foaf:name "Green Goblin".`),
 		expectedTokens: []string{
 			"@prefix",
 			"foaf:",
@@ -374,8 +374,8 @@ var scanTestCases = map[string]struct {
 	},
 	"apostrophe_literal": {
 		data: []byte(`@prefix foaf: <http://xmlns.com/foaf/0.1/> .
-		
-		<http://example.org/green-goblin> foaf:name 'Weird Name With " in it' .`),
+
+				<http://example.org/green-goblin> foaf:name 'Weird Name With " in it' .`),
 		expectedTokens: []string{
 			"@prefix",
 			"foaf:",
@@ -392,8 +392,8 @@ var scanTestCases = map[string]struct {
 	},
 	"apostrophe_in_quotation_mark_literal": {
 		data: []byte(`@prefix foaf: <http://xmlns.com/foaf/0.1/> .
-		
-		<http://example.org/green-goblin> foaf:name "Weird Name With ' in it" .`),
+
+				<http://example.org/green-goblin> foaf:name "Weird Name With ' in it" .`),
 		expectedTokens: []string{
 			"@prefix",
 			"foaf:",
@@ -410,8 +410,8 @@ var scanTestCases = map[string]struct {
 	},
 	"mind_gt_lt_in_literal": {
 		data: []byte(`@prefix foaf: <http://xmlns.com/foaf/0.1/> .
-		
-		<http://example.org/green-goblin> foaf:name "Weird Name With < and > and < in it", <http://example.org/some-iri> .`),
+
+				<http://example.org/green-goblin> foaf:name "Weird Name With < and > and < in it", <http://example.org/some-iri> .`),
 		expectedTokens: []string{
 			"@prefix",
 			"foaf:",
@@ -427,6 +427,200 @@ var scanTestCases = map[string]struct {
 		expectedTriples: [][3]string{
 			{"http://example.org/green-goblin", "http://xmlns.com/foaf/0.1/name", `Weird Name With < and > and < in it`},
 			{"http://example.org/green-goblin", "http://xmlns.com/foaf/0.1/name", "http://example.org/some-iri"},
+		},
+	},
+	"quation-mark-multiline-literal": {
+		data: []byte(`@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+			@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+			@prefix schema: <https://schema.org/> .
+
+			schema:ComicSeries a rdfs:Class ;
+				rdfs:label "ComicSeries" ;
+				rdfs:comment """A sequential publication of comic stories under a
+	unifying title, for example "The Amazing Spider-Man" or "Groo the
+	Wanderer".""" ;
+				rdfs:subClassOf schema:Periodical ;
+				schema:isPartOf <https://bib.schema.org> .`),
+		expectedTokens: []string{
+			`@prefix`,
+			`rdf:`,
+			`<http://www.w3.org/1999/02/22-rdf-syntax-ns#>`,
+			`.`,
+			`@prefix`,
+			`rdfs:`,
+			`<http://www.w3.org/2000/01/rdf-schema#>`,
+			`.`,
+			`@prefix`,
+			`schema:`,
+			`<https://schema.org/>`,
+			`.`,
+			`schema:ComicSeries`,
+			`a`,
+			`rdfs:Class`,
+			`;`,
+			`rdfs:label`,
+			`"ComicSeries"`,
+			`;`,
+			`rdfs:comment`,
+			`"""A sequential publication of comic stories under a
+	unifying title, for example "The Amazing Spider-Man" or "Groo the
+	Wanderer"."""`,
+			`;`,
+			`rdfs:subClassOf`,
+			`schema:Periodical`,
+			`;`,
+			`schema:isPartOf`,
+			`<https://bib.schema.org>`,
+			`.`,
+		},
+		expectedTriples: [][3]string{
+			{"https://schema.org/ComicSeries", "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "http://www.w3.org/2000/01/rdf-schema#/Class"},
+			{"https://schema.org/ComicSeries", "http://www.w3.org/2000/01/rdf-schema#/label", "ComicSeries"},
+			{"https://schema.org/ComicSeries", "http://www.w3.org/2000/01/rdf-schema#/comment", `A sequential publication of comic stories under a
+	unifying title, for example "The Amazing Spider-Man" or "Groo the
+	Wanderer".`},
+			{"https://schema.org/ComicSeries", "http://www.w3.org/2000/01/rdf-schema#/subClassOf", "https://schema.org/Periodical"},
+			{"https://schema.org/ComicSeries", "https://schema.org/isPartOf", "https://bib.schema.org"},
+		},
+	},
+	"apostrophe-multiline-literal": {
+		data: []byte(`@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+				@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+				@prefix schema: <https://schema.org/> .
+
+				schema:ComicSeries a rdfs:Class ;
+					rdfs:label "ComicSeries" ;
+					rdfs:comment '''A sequential publication of comic stories under a
+		unifying title, for example "The Amazing Spider-Man" or "Groo the
+		Wanderer".''' ;
+					rdfs:subClassOf schema:Periodical ;
+					schema:isPartOf <https://bib.schema.org> .`),
+		expectedTokens: []string{
+			`@prefix`,
+			`rdf:`,
+			`<http://www.w3.org/1999/02/22-rdf-syntax-ns#>`,
+			`.`,
+			`@prefix`,
+			`rdfs:`,
+			`<http://www.w3.org/2000/01/rdf-schema#>`,
+			`.`,
+			`@prefix`,
+			`schema:`,
+			`<https://schema.org/>`,
+			`.`,
+			`schema:ComicSeries`,
+			`a`,
+			`rdfs:Class`,
+			`;`,
+			`rdfs:label`,
+			`"ComicSeries"`,
+			`;`,
+			`rdfs:comment`,
+			`'''A sequential publication of comic stories under a
+		unifying title, for example "The Amazing Spider-Man" or "Groo the
+		Wanderer".'''`,
+			`;`,
+			`rdfs:subClassOf`,
+			`schema:Periodical`,
+			`;`,
+			`schema:isPartOf`,
+			`<https://bib.schema.org>`,
+			`.`,
+		},
+		expectedTriples: [][3]string{
+			{"https://schema.org/ComicSeries", "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "http://www.w3.org/2000/01/rdf-schema#/Class"},
+			{"https://schema.org/ComicSeries", "http://www.w3.org/2000/01/rdf-schema#/label", "ComicSeries"},
+			{"https://schema.org/ComicSeries", "http://www.w3.org/2000/01/rdf-schema#/comment", `A sequential publication of comic stories under a
+		unifying title, for example "The Amazing Spider-Man" or "Groo the
+		Wanderer".`},
+			{"https://schema.org/ComicSeries", "http://www.w3.org/2000/01/rdf-schema#/subClassOf", "https://schema.org/Periodical"},
+			{"https://schema.org/ComicSeries", "https://schema.org/isPartOf", "https://bib.schema.org"},
+		},
+	},
+	"escaped-quation": {
+		data: []byte(`
+			@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+			@prefix schema: <https://schema.org/> .
+			schema:FAQPage a rdfs:Class ;
+	rdfs:label "FAQPage" ;
+	rdfs:comment "A [[FAQPage]] is a [[WebPage]] presenting one or more \"[Frequently asked questions](https://en.wikipedia.org/wiki/FAQ)\" (see also [[QAPage]])." ;
+	rdfs:subClassOf schema:WebPage ;
+	schema:source <https://github.com/schemaorg/schemaorg/issues/1723> .`),
+		expectedTokens: []string{
+			`@prefix`,
+			`rdfs:`,
+			`<http://www.w3.org/2000/01/rdf-schema#>`,
+			`.`,
+			`@prefix`,
+			`schema:`,
+			`<https://schema.org/>`,
+			`.`,
+			`schema:FAQPage`,
+			`a`,
+			`rdfs:Class`,
+			`;`,
+			`rdfs:label`,
+			`"FAQPage"`,
+			`;`,
+			`rdfs:comment`,
+			`"A [[FAQPage]] is a [[WebPage]] presenting one or more \"[Frequently asked questions](https://en.wikipedia.org/wiki/FAQ)\" (see also [[QAPage]])."`,
+			`;`,
+			`rdfs:subClassOf`,
+			`schema:WebPage`,
+			`;`,
+			`schema:source`,
+			`<https://github.com/schemaorg/schemaorg/issues/1723>`,
+			`.`,
+		},
+		expectedTriples: [][3]string{
+			{"https://schema.org/FAQPage", "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "http://www.w3.org/2000/01/rdf-schema#/Class"},
+			{"https://schema.org/FAQPage", "http://www.w3.org/2000/01/rdf-schema#/label", "FAQPage"},
+			{"https://schema.org/FAQPage", "http://www.w3.org/2000/01/rdf-schema#/comment", `A [[FAQPage]] is a [[WebPage]] presenting one or more \"[Frequently asked questions](https://en.wikipedia.org/wiki/FAQ)\" (see also [[QAPage]]).`},
+			{"https://schema.org/FAQPage", "http://www.w3.org/2000/01/rdf-schema#/subClassOf", "https://schema.org/WebPage"},
+			{"https://schema.org/FAQPage", "https://schema.org/source", "https://github.com/schemaorg/schemaorg/issues/1723"},
+		},
+	},
+	"escaped-apostrophe": {
+		data: []byte(`
+		@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+		@prefix schema: <https://schema.org/> .
+		schema:FAQPage a rdfs:Class ;
+rdfs:label "FAQPage" ;
+rdfs:comment 'A [[FAQPage]] is a [[WebPage]] presenting one or more \'[Frequently asked questions](https://en.wikipedia.org/wiki/FAQ)\' (see also [[QAPage]]).' ;
+rdfs:subClassOf schema:WebPage ;
+schema:source <https://github.com/schemaorg/schemaorg/issues/1723> .`),
+		expectedTokens: []string{
+			`@prefix`,
+			`rdfs:`,
+			`<http://www.w3.org/2000/01/rdf-schema#>`,
+			`.`,
+			`@prefix`,
+			`schema:`,
+			`<https://schema.org/>`,
+			`.`,
+			`schema:FAQPage`,
+			`a`,
+			`rdfs:Class`,
+			`;`,
+			`rdfs:label`,
+			`"FAQPage"`,
+			`;`,
+			`rdfs:comment`,
+			`'A [[FAQPage]] is a [[WebPage]] presenting one or more \'[Frequently asked questions](https://en.wikipedia.org/wiki/FAQ)\' (see also [[QAPage]]).'`,
+			`;`,
+			`rdfs:subClassOf`,
+			`schema:WebPage`,
+			`;`,
+			`schema:source`,
+			`<https://github.com/schemaorg/schemaorg/issues/1723>`,
+			`.`,
+		},
+		expectedTriples: [][3]string{
+			{"https://schema.org/FAQPage", "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "http://www.w3.org/2000/01/rdf-schema#/Class"},
+			{"https://schema.org/FAQPage", "http://www.w3.org/2000/01/rdf-schema#/label", "FAQPage"},
+			{"https://schema.org/FAQPage", "http://www.w3.org/2000/01/rdf-schema#/comment", `A [[FAQPage]] is a [[WebPage]] presenting one or more \'[Frequently asked questions](https://en.wikipedia.org/wiki/FAQ)\' (see also [[QAPage]]).`},
+			{"https://schema.org/FAQPage", "http://www.w3.org/2000/01/rdf-schema#/subClassOf", "https://schema.org/WebPage"},
+			{"https://schema.org/FAQPage", "https://schema.org/source", "https://github.com/schemaorg/schemaorg/issues/1723"},
 		},
 	},
 }


### PR DESCRIPTION
There is a missing support for multiline literals. Those are denoted either by `'''` or `"""` and can contain _new line_ characters.