### PR TITLE
Adjust assert.Equal to dump structs with full type descriptions on error

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -13,7 +13,7 @@ func Equal(t *testing.T, expected, actual interface{}, msg string, args ...inter
 		return
 	}
 
-	t.Errorf("%s: expected: %s\n actual: %s", fmt.Sprintf(msg, args...), expected, actual)
+	t.Errorf("%s: expected: %#v\n actual: %#v", fmt.Sprintf(msg, args...), expected, actual)
 }
 
 func NoError(t *testing.T, err error, msg string, args ...interface{}) {


### PR DESCRIPTION
This was sorely needed to debug another change I was working on, which I will PR shortly. It's up to you if you want it.