### PR TITLE
adjust unmarshal to implement storage of base and prefixes per triple

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/nvkp/turtle.svg)](https://pkg.go.dev/github.com/nvkp/turtle)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-This [Golang](https://go.dev/) package serves as a serializer and parser of the [Turtle](https://www.w3.org/TR/turtle/) format used for representing [RDF](https://www.w3.org/RDF/) data. This package covers most features of the format's **version 1.1**. 
+This [Golang](https://go.dev/) package serves as a serializer and parser of the [Turtle](https://www.w3.org/TR/turtle/) format used for representing [RDF](https://www.w3.org/RDF/) data. This package covers most features of the format's **version 1.1**.
 
 ## Usage
 
@@ -13,7 +13,7 @@ To add this package as a dependency to you Golang module, run:
 go get github.com/nvkp/turtle
 ```
 
-The API of the package follows the Golang's traditional pattern for serializing and parsing. The serializing operation happens through the `turtle.Marshal(v interface{}) ([]byte, error)` function. The function accepts the to-be-serialized data as an empty interface and returns the byte slice with the result and possible error value. 
+The API of the package follows the Golang's traditional pattern for serializing and parsing. The serializing operation happens through the `turtle.Marshal(v interface{}) ([]byte, error)` function. The function accepts the to-be-serialized data as an empty interface and returns the byte slice with the result and possible error value.
 
 It is able to handle single struct, struct, a slice, an array or a pointer to all three. The fields of the structs passed to the function have to be annotated by tags defining which of the fields correspond to which part of the RDF triple.
 
@@ -74,19 +74,24 @@ fmt.Println(triple) // {http://e.org/person/Mark_Twain http://e.org/relation/aut
 
 The `turtle.Unmarshal` function accepts the compact version of Turtle just as the N-triples version of the format where each row corresponds to a single triple. It reads `@base` and `@prefix` forms and extends the IRIs that are filled in the target structure with them. It ignores Turtle comments, labels and data types. The keyword `a` gets replaced by `http://www.w3.org/1999/02/22-rdf-syntax-ns#type` IRI. The function is able to handle multiline literals, literal floats, blank nodes, blank node lists and RDF collections.
 
+If the `turtle:"base"` struct tag points at a `string` or `turtle:"prefix"` with `map[string]string` is provided, those fields will be filled in with the base and collection of prefixes respectively. This is per-struct and any future pragma encountered will only effect the following triples.
+
 ```golang
 var triples = []struct {
-	Subject   string `turtle:"subject"`
-	Predicate string `turtle:"predicate"`
-	Object    string `turtle:"object"`
+	Subject   string            `turtle:"subject"`
+	Predicate string            `turtle:"predicate"`
+	Object    string            `turtle:"object"`
+    Prefixes  map[string]string `turtle:"prefix"`
+    Base	  string            `turtle:"base"`
 }{}
 
 rdf := `
+@base <http://e.org/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix rel: <http://www.perceive.net/schemas/relationship/> .
 
-<http://e.org/green-goblin>
-	rel:enemyOf <http://e.org/spiderman> ;
+</green-goblin>
+	rel:enemyOf </spiderman> ;
 	a foaf:Person ;
 	foaf:name "Green Goblin" .
 `
@@ -126,9 +131,9 @@ err := turtle.Unmarshal(
 
 ## Existing Alternatives
 
-There is at least one Golang package available on Github that lets you parse and serialize Turtle data: [github.com/deiu/rdf2go](https://github.com/deiu/rdf2go). Its API does not comply with the traditional way of parsing and serializing in Golang programs. It defines its own types appearing in the RDF domain as Triple, Graph, etc. 
+There is at least one Golang package available on Github that lets you parse and serialize Turtle data: [github.com/deiu/rdf2go](https://github.com/deiu/rdf2go). Its API does not comply with the traditional way of parsing and serializing in Golang programs. It defines its own types appearing in the RDF domain as Triple, Graph, etc.
 
-When a user needs a package that would parse and serialize Turtle data, it is fair to suppose that the user has already defined its own RDF data types as triple or graph. In that case for using the above mentioned package, user has to create a logic for converting its triple data types into the package's data types and adding them to the package's graph structure. 
+When a user needs a package that would parse and serialize Turtle data, it is fair to suppose that the user has already defined its own RDF data types as triple or graph. In that case for using the above mentioned package, user has to create a logic for converting its triple data types into the package's data types and adding them to the package's graph structure.
 
 More "Golang way" that this package offers is to annotated the user's already defined structures and the package would read these annotations and behave accordingly.
 
@@ -140,7 +145,7 @@ This benchmark compares parsing and serializing operations of the [github.com/de
 goos: linux
 goarch: amd64
 pkg: github.com/nvkp/turtletest
-cpu: AMD Ryzen 7 PRO 5850U with Radeon Graphics     
+cpu: AMD Ryzen 7 PRO 5850U with Radeon Graphics
 BenchmarkMarshalTurtle-16         205250              5801 ns/op
 BenchmarkMarshalRDF2Go-16         163112              6384 ns/op
 BenchmarkUnmarshalTurtle-16            9         123448964 ns/op

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -29,6 +29,14 @@ type namedTypeTriple struct {
 	o object    `turtle:"object"`
 }
 
+type tripleWithMetadata struct {
+	Subject   string            `turtle:"subject"`
+	Predicate string            `turtle:"predicate"`
+	Object    string            `turtle:"object"`
+	Prefixes  map[string]string `turtle:"prefix"`
+	Base      string            `turtle:"base"`
+}
+
 var marshalTestCases = map[string]struct {
 	triples   interface{}
 	expString string

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -65,7 +65,8 @@ func unmarshal(s *scanner.Scanner, v reflect.Value) error {
 		if !ok {
 			return nil
 		}
-		return unmarshalStruct(s, v)
+		err, _ := unmarshalStruct(s, v)
+		return err
 	}
 
 	return nil
@@ -81,6 +82,7 @@ func unmarshalSlice(s *scanner.Scanner, v reflect.Value) error {
 	for s.Next() {
 		var item reflect.Value
 		var err error
+		var ok bool
 
 		switch itemType.Kind() {
 		case reflect.Pointer:
@@ -88,18 +90,22 @@ func unmarshalSlice(s *scanner.Scanner, v reflect.Value) error {
 			// reflect pointer to element zero value and call unmarshalStruct on
 			// the pointer's element
 			item = reflect.New(itemType.Elem())
-			err = unmarshalStruct(s, item.Elem())
+			err, ok = unmarshalStruct(s, item.Elem())
 		case reflect.Struct:
 			// if slice contains structs, create item as
 			// zero value struct and call unmarshalStruct on it
 			item = reflect.New(itemType).Elem()
-			err = unmarshalStruct(s, item)
+			err, ok = unmarshalStruct(s, item)
 		default:
 			return errors.New("invalid slice's item type")
 		}
 
 		if err != nil {
 			return err
+		}
+
+		if !ok {
+			break
 		}
 
 		if !v.CanSet() {
@@ -113,18 +119,34 @@ func unmarshalSlice(s *scanner.Scanner, v reflect.Value) error {
 	return nil
 }
 
-func unmarshalStruct(s *scanner.Scanner, v reflect.Value) error {
+func unmarshalStruct(s *scanner.Scanner, v reflect.Value) (error, bool) {
 	if v.Kind() != reflect.Struct {
-		return errors.New("value not struct")
+		return errors.New("value not struct"), false
 	}
-	t := s.TripleWithAnnotations()
+
+	var t [5]string
+
+	// prevent empty structs from being generated from pragmas
+outer:
+	for {
+		t = s.TripleWithAnnotations()
+		for _, k := range t {
+			if k != "" {
+				break outer
+			}
+		}
+		if !s.Next() {
+			return nil, false
+		}
+	}
+
 	numField := v.NumField()
 	_ = numField
 	for i := 0; i < v.NumField(); i++ {
 		field := v.Field(i)
 
 		if !field.CanSet() {
-			return errors.New("field cannot be changed")
+			return errors.New("field cannot be changed"), false
 		}
 
 		// get the tag value
@@ -147,35 +169,49 @@ func unmarshalStruct(s *scanner.Scanner, v reflect.Value) error {
 			part = label
 		case "datatype":
 			part = datatype
+		case "base", "prefix":
+			part = -1
 		}
-		word = t[part]
+
+		if part >= 0 {
+			word = t[part]
+		}
 
 		// if field is string set value
-		if field.Kind() == reflect.String {
-			field.SetString(word)
-		}
-
-		// if field is pointer
-		if field.Kind() == reflect.Pointer {
+		if field.Kind() == reflect.String && tag != "prefix" {
+			if tag == "base" {
+				field.SetString(s.Base())
+			} else {
+				field.SetString(word)
+			}
+		} else if field.Kind() == reflect.Map && tag == "prefix" && isMap(field.Type()) {
+			field.Set(reflect.ValueOf(s.Prefixes()))
+		} else if field.Kind() == reflect.Pointer {
 			pointerType := field.Type().Elem()
-			// check that the field is pointer to string
-			if pointerType.Kind() != reflect.String {
-				continue
-			}
-
-			// omit empty strings
-			if len(word) == 0 {
-				continue
-			}
-
 			// create new reflect value of pointer to string
-			stringValue := reflect.New(pointerType)
-			// set value to the pointed string
-			stringValue.Elem().SetString(word)
-			// set the pointer as value of the struct field
-			field.Set(stringValue)
+			value := reflect.New(pointerType)
+
+			// check that the field is pointer to string
+			if pointerType.Kind() == reflect.String {
+
+				// omit empty strings
+				if len(word) == 0 {
+					continue
+				}
+
+				// set value to the pointed string
+				value.Elem().SetString(word)
+				// set the pointer as value of the struct field
+				field.Set(value)
+			} else if isMap(pointerType) {
+				field.Set(value)
+			}
 		}
 	}
 
-	return nil
+	return nil, true
+}
+
+func isMap(value reflect.Type) bool {
+	return value.Key().Kind() == reflect.String && value.Elem().Kind() == reflect.String
 }

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -129,3 +129,25 @@ func TestUnmarshalNotAPointer(t *testing.T) {
 	err := turtle.Unmarshal(data, target)
 	assert.ErrorIs(t, err, turtle.ErrNoPointerValue, "function Unmarshal should have returned correct error")
 }
+
+func TestUnmarshalBaseAndPrefixes(t *testing.T) {
+	target := make([]tripleWithMetadata, 0)
+	data := []byte(`
+@base <http://example.org/> .
+@prefix books: <https://amazon.com/> .
+</person/Mark_Twain> </relation/author> <books:Huckleberry_Finn> .`)
+
+	expected := []tripleWithMetadata{
+		{
+			Base:      "http://example.org/",
+			Prefixes:  map[string]string{"books": "https://amazon.com/"},
+			Subject:   "/person/Mark_Twain",
+			Predicate: "/relation/author",
+			Object:    "books:Huckleberry_Finn",
+		},
+	}
+
+	err := turtle.Unmarshal(data, &target)
+	assert.NoError(t, err, "got an error unmarshaling turtle with base and prefixes")
+	assert.Equal(t, expected, target, "not equal to expected data")
+}


### PR DESCRIPTION
I just realized I didn't add docs; I will do that in a minute in a second commit.

This change unravels RDF 1.1 `@base` and `@prefix` (note: RDF 1.2 changes these to `BASE` and `PREFIX`) into structs that are tagged with `base` and `prefix` respectively. To be safe, and to allow for appropriate relative resource construction, it does this per-triple. It also fixes a bug where either pragma would generate an empty triple in the slice marshaler; that's the changes to `unmarshalStruct` around return signatures.

I want to do another change that does relative construction and decomposition on the i/o but I didn't want to do too much per-patch. This library makes me pretty happy.