### PR TITLE
Resolve urls according to base and prefix settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/nvkp/turtle.svg)](https://pkg.go.dev/github.com/nvkp/turtle)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-This [Golang](https://go.dev/) package serves as a serializer and parser of the [Turtle](https://www.w3.org/TR/turtle/) format used for representing [RDF](https://www.w3.org/RDF/) data. This package covers most features of the format's **version 1.1**. 
+This [Golang](https://go.dev/) package serves as a serializer and parser of the [Turtle](https://www.w3.org/TR/turtle/) format used for representing [RDF](https://www.w3.org/RDF/) data. This package covers most features of the format's **version 1.1**.
 
 ## Usage
 
@@ -13,7 +13,7 @@ To add this package as a dependency to you Golang module, run:
 go get github.com/nvkp/turtle
 ```
 
-The API of the package follows the Golang's traditional pattern for serializing and parsing. The serializing operation happens through the `turtle.Marshal(v interface{}) ([]byte, error)` function. The function accepts the to-be-serialized data as an empty interface and returns the byte slice with the result and possible error value. 
+The API of the package follows the Golang's traditional pattern for serializing and parsing. The serializing operation happens through the `turtle.Marshal(v interface{}) ([]byte, error)` function. The function accepts the to-be-serialized data as an empty interface and returns the byte slice with the result and possible error value.
 
 It is able to handle single struct, struct, a slice, an array or a pointer to all three. The fields of the structs passed to the function have to be annotated by tags defining which of the fields correspond to which part of the RDF triple.
 
@@ -74,19 +74,24 @@ fmt.Println(triple) // {http://e.org/person/Mark_Twain http://e.org/relation/aut
 
 The `turtle.Unmarshal` function accepts the compact version of Turtle just as the N-triples version of the format where each row corresponds to a single triple. It reads `@base` and `@prefix` forms and extends the IRIs that are filled in the target structure with them. It ignores Turtle comments, labels and data types. The keyword `a` gets replaced by `http://www.w3.org/1999/02/22-rdf-syntax-ns#type` IRI. The function is able to handle multiline literals, literal floats, blank nodes, blank node lists and RDF collections.
 
+If the `turtle:"base"` struct tag points at a `string` or `turtle:"prefix"` with `map[string]string` is provided, those fields will be filled in with the base and collection of prefixes respectively. This is per-struct and any future pragma encountered will only effect the following triples.
+
 ```golang
 var triples = []struct {
-	Subject   string `turtle:"subject"`
-	Predicate string `turtle:"predicate"`
-	Object    string `turtle:"object"`
+	Subject   string            `turtle:"subject"`
+	Predicate string            `turtle:"predicate"`
+	Object    string            `turtle:"object"`
+    Prefixes  map[string]string `turtle:"prefix"`
+    Base	  string            `turtle:"base"`
 }{}
 
 rdf := `
+@base <http://e.org/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix rel: <http://www.perceive.net/schemas/relationship/> .
 
-<http://e.org/green-goblin>
-	rel:enemyOf <http://e.org/spiderman> ;
+</green-goblin>
+	rel:enemyOf </spiderman> ;
 	a foaf:Person ;
 	foaf:name "Green Goblin" .
 `
@@ -126,9 +131,9 @@ err := turtle.Unmarshal(
 
 ## Existing Alternatives
 
-There is at least one Golang package available on Github that lets you parse and serialize Turtle data: [github.com/deiu/rdf2go](https://github.com/deiu/rdf2go). Its API does not comply with the traditional way of parsing and serializing in Golang programs. It defines its own types appearing in the RDF domain as Triple, Graph, etc. 
+There is at least one Golang package available on Github that lets you parse and serialize Turtle data: [github.com/deiu/rdf2go](https://github.com/deiu/rdf2go). Its API does not comply with the traditional way of parsing and serializing in Golang programs. It defines its own types appearing in the RDF domain as Triple, Graph, etc.
 
-When a user needs a package that would parse and serialize Turtle data, it is fair to suppose that the user has already defined its own RDF data types as triple or graph. In that case for using the above mentioned package, user has to create a logic for converting its triple data types into the package's data types and adding them to the package's graph structure. 
+When a user needs a package that would parse and serialize Turtle data, it is fair to suppose that the user has already defined its own RDF data types as triple or graph. In that case for using the above mentioned package, user has to create a logic for converting its triple data types into the package's data types and adding them to the package's graph structure.
 
 More "Golang way" that this package offers is to annotated the user's already defined structures and the package would read these annotations and behave accordingly.
 
@@ -140,7 +145,7 @@ This benchmark compares parsing and serializing operations of the [github.com/de
 goos: linux
 goarch: amd64
 pkg: github.com/nvkp/turtletest
-cpu: AMD Ryzen 7 PRO 5850U with Radeon Graphics     
+cpu: AMD Ryzen 7 PRO 5850U with Radeon Graphics
 BenchmarkMarshalTurtle-16         205250              5801 ns/op
 BenchmarkMarshalRDF2Go-16         163112              6384 ns/op
 BenchmarkUnmarshalTurtle-16            9         123448964 ns/op

--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ fmt.Println(triple) // {http://e.org/person/Mark_Twain http://e.org/relation/aut
 
 The `turtle.Unmarshal` function accepts the compact version of Turtle just as the N-triples version of the format where each row corresponds to a single triple. It reads `@base` and `@prefix` forms and extends the IRIs that are filled in the target structure with them. It ignores Turtle comments, labels and data types. The keyword `a` gets replaced by `http://www.w3.org/1999/02/22-rdf-syntax-ns#type` IRI. The function is able to handle multiline literals, literal floats, blank nodes, blank node lists and RDF collections.
 
-If the `turtle:"base"` struct tag points at a `string` or `turtle:"prefix"` with `map[string]string` is provided, those fields will be filled in with the base and collection of prefixes respectively. This is per-struct and any future pragma encountered will only effect the following triples.
+If the `turtle:"base"` struct tag points at a `string` or `turtle:"prefix"` with `map[string]string` is provided, those fields will be filled in with the base and collection of prefixes respectively. This is per-struct and any future pragma encountered will only effect the following triples. These tags are ignored on marshal, in favor of a configured marshaler. See "Config" for more information.
 
 ```golang
 var triples = []struct {
 	Subject   string            `turtle:"subject"`
 	Predicate string            `turtle:"predicate"`
 	Object    string            `turtle:"object"`
-    Prefixes  map[string]string `turtle:"prefix"`
-    Base	  string            `turtle:"base"`
+	Prefixes  map[string]string `turtle:"prefix"`
+	Base	  string            `turtle:"base"`
 }{}
 
 rdf := `
@@ -129,6 +129,70 @@ err := turtle.Unmarshal(
 )
 ```
 
+If you want to resolve URLs automatically at parsing time, create a _configured_ parser with the `turtle.Config` struct. The fields are as follows:
+
+- ResolveURLs: dynamically expand or shorten URLs relative to Base and Prefixes
+- Base: configure `@base` without providing syntax
+- Prefixes: `map[string]string`, configure prefixes without providing syntax
+
+Base and Prefixes operate exactly like if they were included in the document, and any encountered pragma in a parsed document will affect their representation during unmarshaling.
+
+Example:
+
+```go
+c := turtle.Config{
+    ResolveURLs: true,
+    Base:        "https://example.org/",
+    Prefixes:    map[string]string{
+        "people": "https://example.org/people/types/"
+    },
+}
+
+triple := struct {
+    Subject     string `turtle:"subject"`
+    Predicate   string `turtle:"predicate"`
+    Object      string `turtle:"object"`
+}{
+    Subject: "/people/Mark_Twain",
+    Predicate: "a",
+    Object: "people:author",
+}
+
+data, _ := c.Marshal(triple)
+// <https://example.org/people/Mark_Twain> <RDF IRI URL> <https://example.org/people/types/author> .
+```
+
+For unmarshaling, `@base` and `@prefix` weigh into the behavior of `ResolveURLs`. They will overwrite any configured options before further resolution. To be absolutely sure what base and prefixes you are using, unmarshal them too.
+
+Example:
+
+```go
+c := turtle.Config{
+    ResolveURLs: true,
+    Base:        "https://example.org/",
+    Prefixes:    map[string]string{
+        "people": "https://example.org/people/types/"
+    },
+}
+
+triple := struct {
+    Base        string            `turtle:"base"`
+    Prefixes    map[string]string `turtle:"prefix"`
+    Subject     string            `turtle:"subject"`
+    Predicate   string            `turtle:"predicate"`
+    Object      string            `turtle:"object"`
+}{}
+
+doc := `
+@base <https://example2.org> .
+</people/Mark_Twain> a people:author .
+`
+
+c.Unmarshal([]byte(doc), &triple)
+
+// triple.Base == "https://example2.org"
+```
+
 ## Existing Alternatives
 
 There is at least one Golang package available on Github that lets you parse and serialize Turtle data: [github.com/deiu/rdf2go](https://github.com/deiu/rdf2go). Its API does not comply with the traditional way of parsing and serializing in Golang programs. It defines its own types appearing in the RDF domain as Triple, Graph, etc.
@@ -142,14 +206,16 @@ More "Golang way" that this package offers is to annotated the user's already de
 This benchmark compares parsing and serializing operations of the [github.com/deiu/rdf2go](https://github.com/deiu/rdf2go) and [github.com/nvkp/turtle](https://github.com/nvkp/turtle) packages. Both serializing operations are performed on seven triples repeatadly. The parsing operations are performed on a sample of around 27 000 triples. Both parsing and serializing operations from the [github.com/nvkp/turtle](https://github.com/nvkp/turtle) are performed quicker and consume less memory.
 
 ```
+
 goos: linux
 goarch: amd64
 pkg: github.com/nvkp/turtletest
 cpu: AMD Ryzen 7 PRO 5850U with Radeon Graphics
-BenchmarkMarshalTurtle-16         205250              5801 ns/op
-BenchmarkMarshalRDF2Go-16         163112              6384 ns/op
-BenchmarkUnmarshalTurtle-16            9         123448964 ns/op
-BenchmarkUnmarshalRDF2Go-16            4         261741094 ns/op
+BenchmarkMarshalTurtle-16 205250 5801 ns/op
+BenchmarkMarshalRDF2Go-16 163112 6384 ns/op
+BenchmarkUnmarshalTurtle-16 9 123448964 ns/op
+BenchmarkUnmarshalRDF2Go-16 4 261741094 ns/op
 PASS
-ok      github.com/nvkp/turtletest      7.738s
+ok github.com/nvkp/turtletest 7.738s
+
 ```

--- a/config.go
+++ b/config.go
@@ -1,0 +1,53 @@
+package turtle
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/nvkp/turtle/graph"
+	"github.com/nvkp/turtle/scanner"
+)
+
+type Config struct {
+	ResolveURLs bool
+	Base        string
+	Prefixes    map[string]string
+}
+
+func (c *Config) Marshal(v interface{}) ([]byte, error) {
+	g := graph.NewWithOptions(
+		graph.Options{
+			ResolveURLs: c.ResolveURLs,
+			Base:        c.Base,
+			Prefixes:    c.Prefixes,
+		})
+	if err := marshal(g, reflect.ValueOf(v)); err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	return g.Bytes()
+}
+
+func (c *Config) Unmarshal(data []byte, v interface{}) error {
+	if v == nil {
+		return ErrNilValue
+	}
+
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr {
+		return ErrNoPointerValue
+	}
+
+	err := unmarshal(
+		scanner.NewWithOptions(data,
+			scanner.Options{
+				ResolveURLs: c.ResolveURLs,
+				Base:        c.Base,
+				Prefixes:    c.Prefixes,
+			}),
+		rv)
+	if err != nil {
+		return fmt.Errorf("unmarshal: %v", err)
+	}
+
+	return nil
+}

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -16,8 +16,8 @@ var graphTestCases = map[string]struct {
 			{"a", "b", "c"},
 			{"c", "d", "e"},
 		},
-		expected: []byte(`"a" <b> "c" .
-"c" <d> "e" .
+		expected: []byte(`"a" b "c" .
+"c" d "e" .
 `),
 	},
 	"subject_with_two_predicates": {
@@ -26,8 +26,8 @@ var graphTestCases = map[string]struct {
 			{"a", "c", "e"},
 		},
 		expected: []byte(`"a" 
-	<b> "c" ;
-	<c> "e" .
+	b "c" ;
+	c "e" .
 `),
 	},
 	"predicate_with_two_objects": {
@@ -35,7 +35,7 @@ var graphTestCases = map[string]struct {
 			{"a", "b", "c"},
 			{"a", "b", "d"},
 		},
-		expected: []byte(`"a" <b> "c", "d" .
+		expected: []byte(`"a" b "c", "d" .
 `),
 	},
 	"two_predicates_with_two_objects": {
@@ -46,8 +46,8 @@ var graphTestCases = map[string]struct {
 			{"a", "e", "d"},
 		},
 		expected: []byte(`"a" 
-	<b> "c", "d" ;
-	<e> "c", "d" .
+	b "c", "d" ;
+	e "c", "d" .
 `),
 	},
 }

--- a/graph/sanitize_test.go
+++ b/graph/sanitize_test.go
@@ -7,50 +7,64 @@ import (
 )
 
 var sanitizesTestCases = map[string]struct {
-	str      string
-	expected string
+	str                string
+	expected           string
+	predicate_expected string
 }{
 	"empty_string": {
-		str:      "",
-		expected: "",
+		str:                "",
+		expected:           "",
+		predicate_expected: "",
 	},
 	"iri": {
-		str:      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
-		expected: "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>",
+		str:                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+		expected:           "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>",
+		predicate_expected: "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>",
 	},
 	"blank_node": {
-		str:      "_:b23",
-		expected: "_:b23",
+		str:                "_:b23",
+		expected:           "_:b23",
+		predicate_expected: "_:b23",
 	},
 	"literal": {
-		str:      "this is a literal",
-		expected: `"this is a literal"`,
+		str:                "this is a literal",
+		expected:           `"this is a literal"`,
+		predicate_expected: `this is a literal`,
 	},
 	"multiline literal": {
 		str: `this is a
 literal`,
 		expected: `'''this is a
 literal'''`,
+		predicate_expected: `this is a
+literal`,
 	},
 	"multiline_literal_apostrophe": {
 		str: `this is 'a
 literal`,
 		expected: `"""this is 'a
 literal"""`,
+		predicate_expected: `this is 'a
+literal`,
 	},
 	"multiline_literal_quotation": {
 		str: `this is "a
 literal`,
 		expected: `'''this is "a
 literal'''`,
+		predicate_expected: `this is "a
+literal`,
 	},
 }
 
 func TestSanitize(t *testing.T) {
+	g := New()
 	for name, tc := range sanitizesTestCases {
 		t.Run(name, func(t *testing.T) {
-			actual := sanitize(tc.str)
+			actual := g.sanitize(tc.str, false)
 			assert.Equal(t, tc.expected, actual, "function should have returned correctly sanitized string")
+			actual = g.sanitize(tc.str, true)
+			assert.Equal(t, tc.predicate_expected, actual, "function should have returned correctly sanitized string")
 		})
 	}
 }

--- a/marshal.go
+++ b/marshal.go
@@ -1,7 +1,6 @@
 package turtle
 
 import (
-	"fmt"
 	"reflect"
 
 	"errors"
@@ -34,11 +33,7 @@ var (
 // triples are sorted alphabetically first by subjects, then by predicates
 // and then by objects.
 func Marshal(v interface{}) ([]byte, error) {
-	g := graph.New()
-	if err := marshal(g, reflect.ValueOf(v)); err != nil {
-		return nil, fmt.Errorf("marshal: %w", err)
-	}
-	return g.Bytes()
+	return (&Config{}).Marshal(v)
 }
 
 func marshal(g *graph.Graph, v reflect.Value) error {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -29,6 +29,14 @@ type namedTypeTriple struct {
 	o object    `turtle:"object"`
 }
 
+type tripleWithMetadata struct {
+	Subject   string            `turtle:"subject"`
+	Predicate string            `turtle:"predicate"`
+	Object    string            `turtle:"object"`
+	Prefixes  map[string]string `turtle:"prefix"`
+	Base      string            `turtle:"base"`
+}
+
 var marshalTestCases = map[string]struct {
 	triples   interface{}
 	expString string

--- a/scanner/sanitize.go
+++ b/scanner/sanitize.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 )
 
@@ -12,18 +13,45 @@ const (
 
 func (s *Scanner) sanitize(token string) (string, string, string) {
 	var label, datatype string
-	// apply the stored prefixes
-	for prefix, value := range s.prefixes {
-		if !strings.HasPrefix(token, fmt.Sprintf("%s:", prefix)) {
-			continue
+
+	if !s.options.ResolveURLs {
+		// apply the stored prefixes
+		for prefix, value := range s.prefixes {
+			if !strings.HasPrefix(token, fmt.Sprintf("%s:", prefix)) {
+				continue
+			}
+			i := strings.IndexAny(token, ":")
+			token = fmt.Sprintf("%s%s", value, token[i+1:])
 		}
-		i := strings.IndexAny(token, ":")
-		token = fmt.Sprintf("%s%s", value, token[i+1:])
 	}
 
 	// apply the stored base
-	if strings.HasPrefix(token, "<#") {
-		token = fmt.Sprintf("%s%s", s.base, token[2:])
+	if strings.HasPrefix(token, "<") {
+		token = trim(token)
+		if s.options.ResolveURLs {
+			for prefix, value := range s.prefixes {
+				if strings.HasPrefix(token, value) {
+					token = fmt.Sprintf("%s:%s", prefix, strings.TrimPrefix(token, value))
+				}
+			}
+		}
+
+		u, _ := url.Parse(token)
+		if u == nil || u.Host == "" && s.base != "" {
+			// special case for blank anchors
+			if s.base[len(s.base)-1] == '#' || token[0] == '#' {
+				if token != "" && token[0] == '#' {
+					token = token[1:]
+				}
+
+				token = s.base + token
+			} else if s.options.ResolveURLs {
+				b, err := url.Parse(s.base)
+				if err == nil {
+					token = b.JoinPath(token).String()
+				}
+			}
+		}
 	}
 
 	// extract data type suffix

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -65,7 +65,8 @@ func unmarshal(s *scanner.Scanner, v reflect.Value) error {
 		if !ok {
 			return nil
 		}
-		return unmarshalStruct(s, v)
+		err, _ := unmarshalStruct(s, v)
+		return err
 	}
 
 	return nil
@@ -81,6 +82,7 @@ func unmarshalSlice(s *scanner.Scanner, v reflect.Value) error {
 	for s.Next() {
 		var item reflect.Value
 		var err error
+		var ok bool
 
 		switch itemType.Kind() {
 		case reflect.Pointer:
@@ -88,18 +90,22 @@ func unmarshalSlice(s *scanner.Scanner, v reflect.Value) error {
 			// reflect pointer to element zero value and call unmarshalStruct on
 			// the pointer's element
 			item = reflect.New(itemType.Elem())
-			err = unmarshalStruct(s, item.Elem())
+			err, ok = unmarshalStruct(s, item.Elem())
 		case reflect.Struct:
 			// if slice contains structs, create item as
 			// zero value struct and call unmarshalStruct on it
 			item = reflect.New(itemType).Elem()
-			err = unmarshalStruct(s, item)
+			err, ok = unmarshalStruct(s, item)
 		default:
 			return errors.New("invalid slice's item type")
 		}
 
 		if err != nil {
 			return err
+		}
+
+		if !ok {
+			break
 		}
 
 		if !v.CanSet() {
@@ -113,18 +119,34 @@ func unmarshalSlice(s *scanner.Scanner, v reflect.Value) error {
 	return nil
 }
 
-func unmarshalStruct(s *scanner.Scanner, v reflect.Value) error {
+func unmarshalStruct(s *scanner.Scanner, v reflect.Value) (error, bool) {
 	if v.Kind() != reflect.Struct {
-		return errors.New("value not struct")
+		return errors.New("value not struct"), false
 	}
-	t := s.TripleWithAnnotations()
+
+	var t [5]string
+
+	// prevent empty structs from being generated from pragmas
+outer:
+	for {
+		t = s.TripleWithAnnotations()
+		for _, k := range t {
+			if k != "" {
+				break outer
+			}
+		}
+		if !s.Next() {
+			return nil, false
+		}
+	}
+
 	numField := v.NumField()
 	_ = numField
 	for i := 0; i < v.NumField(); i++ {
 		field := v.Field(i)
 
 		if !field.CanSet() {
-			return errors.New("field cannot be changed")
+			return errors.New("field cannot be changed"), false
 		}
 
 		// get the tag value
@@ -147,35 +169,49 @@ func unmarshalStruct(s *scanner.Scanner, v reflect.Value) error {
 			part = label
 		case "datatype":
 			part = datatype
+		case "base", "prefix":
+			part = -1
 		}
-		word = t[part]
+
+		if part >= 0 {
+			word = t[part]
+		}
 
 		// if field is string set value
-		if field.Kind() == reflect.String {
-			field.SetString(word)
-		}
-
-		// if field is pointer
-		if field.Kind() == reflect.Pointer {
+		if field.Kind() == reflect.String && tag != "prefix" {
+			if tag == "base" {
+				field.SetString(s.Base())
+			} else {
+				field.SetString(word)
+			}
+		} else if field.Kind() == reflect.Map && tag == "prefix" && isMap(field.Type()) {
+			field.Set(reflect.ValueOf(s.Prefixes()))
+		} else if field.Kind() == reflect.Pointer {
 			pointerType := field.Type().Elem()
-			// check that the field is pointer to string
-			if pointerType.Kind() != reflect.String {
-				continue
-			}
-
-			// omit empty strings
-			if len(word) == 0 {
-				continue
-			}
-
 			// create new reflect value of pointer to string
-			stringValue := reflect.New(pointerType)
-			// set value to the pointed string
-			stringValue.Elem().SetString(word)
-			// set the pointer as value of the struct field
-			field.Set(stringValue)
+			value := reflect.New(pointerType)
+
+			// check that the field is pointer to string
+			if pointerType.Kind() == reflect.String {
+
+				// omit empty strings
+				if len(word) == 0 {
+					continue
+				}
+
+				// set value to the pointed string
+				value.Elem().SetString(word)
+				// set the pointer as value of the struct field
+				field.Set(value)
+			} else if isMap(pointerType) {
+				field.Set(value)
+			}
 		}
 	}
 
-	return nil
+	return nil, true
+}
+
+func isMap(value reflect.Type) bool {
+	return value.Key().Kind() == reflect.String && value.Elem().Kind() == reflect.String
 }

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -2,7 +2,6 @@ package turtle
 
 import (
 	"errors"
-	"fmt"
 	"reflect"
 
 	"github.com/nvkp/turtle/scanner"
@@ -37,21 +36,7 @@ var (
 // comments, labels and data types. The keyword a gets
 // replaced by http://www.w3.org/1999/02/22-rdf-syntax-ns#type IRI.
 func Unmarshal(data []byte, v interface{}) error {
-	if v == nil {
-		return ErrNilValue
-	}
-
-	rv := reflect.ValueOf(v)
-	if rv.Kind() != reflect.Ptr {
-		return ErrNoPointerValue
-	}
-
-	err := unmarshal(scanner.New(data), rv)
-	if err != nil {
-		return fmt.Errorf("unmarshal: %v", err)
-	}
-
-	return nil
+	return (&Config{}).Unmarshal(data, v)
 }
 
 func unmarshal(s *scanner.Scanner, v reflect.Value) error {

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -129,3 +129,25 @@ func TestUnmarshalNotAPointer(t *testing.T) {
 	err := turtle.Unmarshal(data, target)
 	assert.ErrorIs(t, err, turtle.ErrNoPointerValue, "function Unmarshal should have returned correct error")
 }
+
+func TestUnmarshalBaseAndPrefixes(t *testing.T) {
+	target := make([]tripleWithMetadata, 0)
+	data := []byte(`
+@base <http://example.org/> .
+@prefix books: <https://amazon.com/> .
+</person/Mark_Twain> </relation/author> <books:Huckleberry_Finn> .`)
+
+	expected := []tripleWithMetadata{
+		{
+			Base:      "http://example.org/",
+			Prefixes:  map[string]string{"books": "https://amazon.com/"},
+			Subject:   "/person/Mark_Twain",
+			Predicate: "/relation/author",
+			Object:    "books:Huckleberry_Finn",
+		},
+	}
+
+	err := turtle.Unmarshal(data, &target)
+	assert.NoError(t, err, "got an error unmarshaling turtle with base and prefixes")
+	assert.Equal(t, expected, target, "not equal to expected data")
+}


### PR DESCRIPTION
This feature incorporates my other feature PR and I will close that one.

Please read the README diff for how to use the feature. I added tests and fixed quite a few bugs in the handling of relative URLs and prefixes. I also fixed a predicate bug in the graph generator since it always assumed it was working with full URIs.

I hope this change is satisfactory. I'll add to if it you need any changes, but for now I will merge my PRs into https://github.com/erikh/turtle master and tag it, so I can depend on it. I'd rather not depend on a fork, so let me know what you want.