### PR TITLE
fix:Fix literal/CURIE edge cases in marshal/unmarshal + Turtle scanner

### DIFF
--- a/graph/sanitize.go
+++ b/graph/sanitize.go
@@ -29,15 +29,15 @@ func (g *Graph) sanitizeObject(obj object) string {
 }
 
 func (g *Graph) sanitize(str string, typ string, predicate bool) string {
-	if len(str) == 0 {
-		return str
-	}
-
 	if isBlankNode(str) {
 		return str
 	}
 
 	if typ == "iri" || (typ == "" && isIRI(str)) {
+		if str == "" {
+			return str
+		}
+
 		if str == "." && g.options.Base != "" {
 			return g.options.Base
 		}
@@ -49,6 +49,12 @@ func (g *Graph) sanitize(str string, typ string, predicate bool) string {
 		for key := range g.options.Prefixes {
 			if strings.HasPrefix(str, key+":") {
 				return str
+			}
+		}
+
+		for key, val := range g.options.Prefixes {
+			if strings.HasPrefix(str, val) {
+				return fmt.Sprintf("%s:%s", key, strings.TrimPrefix(str, val))
 			}
 		}
 
@@ -107,11 +113,23 @@ func isValidIRIChar(char rune) bool {
 
 func literalEdge(str string) string {
 	if !strings.ContainsRune(str, runeNewLine) {
+		if !strings.ContainsRune(str, runeQuotation) && !strings.ContainsRune(str, runeApostrophe) {
+			return `"`
+		}
+
 		if !strings.ContainsRune(str, runeQuotation) {
 			return `"`
 		}
 
-		return `'`
+		if !strings.ContainsRune(str, runeApostrophe) {
+			return `'`
+		}
+
+		return `"""`
+	}
+
+	if !strings.ContainsRune(str, runeQuotation) && !strings.ContainsRune(str, runeApostrophe) {
+		return `'''`
 	}
 
 	if strings.ContainsRune(str, runeApostrophe) {

--- a/marshal.go
+++ b/marshal.go
@@ -72,20 +72,29 @@ func marshalStruct(g *graph.Graph, v reflect.Value) error {
 
 		// pick correct part based on the tag value
 		var part int
+		var found bool
 		switch tag {
 		case "subject":
 			part = subject
+			found = true
 		case "predicate":
 			part = predicate
+			found = true
 		case "object":
 			part = object
+			found = true
 		case "label":
 			part = label
+			found = true
 		case "datatype":
 			part = datatype
+			found = true
 		case "objecttype":
 			part = objecttype
-		case "base", "prefix":
+			found = true
+		}
+
+		if !found {
 			continue
 		}
 
@@ -95,7 +104,7 @@ func marshalStruct(g *graph.Graph, v reflect.Value) error {
 			word = field.String()
 		}
 		// is field is pointer to string use the pointed value
-		if field.Kind() == reflect.Pointer && field.Type().Elem().Kind() == reflect.String && field.Elem().Kind() == reflect.String {
+		if field.Kind() == reflect.Pointer && !field.IsNil() && field.Type().Elem().Kind() == reflect.String {
 			word = field.Elem().String()
 		}
 
@@ -111,7 +120,7 @@ func marshalStruct(g *graph.Graph, v reflect.Value) error {
 		return ErrNoPredicateSpecified
 	}
 
-	if t[object] == "" {
+	if t[object] == "" && t[datatype] == "" && t[label] == "" {
 		return ErrNoObjectSpecified
 	}
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -285,7 +285,7 @@ func TestMarshalOptions(t *testing.T) {
 	assert.Equal(t, strings.TrimSpace(string(out)), strings.TrimSpace(`
 @base <http://example.org> .
 @prefix book: <http://example.org/books/> .
-</person/Mark_Twain> </relation/author> </books/Huckleberry_Finn> .
+</person/Mark_Twain> </relation/author> book:Huckleberry_Finn .
 `), "output was not equal")
 
 	// check for weird rdf-isms like using a blank anchor as a prefix
@@ -308,7 +308,7 @@ func TestMarshalOptions(t *testing.T) {
 	assert.Equal(t, strings.TrimSpace(string(out)), strings.TrimSpace(`
 @base <http://example.org> .
 @prefix book: <http://example.org/books#> .
-</person/Mark_Twain> </relation/author> </books#Huckleberry_Finn> .
+</person/Mark_Twain> </relation/author> book:Huckleberry_Finn .
 `), "output was not equal")
 }
 
@@ -337,4 +337,31 @@ func TestMarshalSubjectBaseURLTrailingSlash(t *testing.T) {
 	out, err := (&turtle.Config{Base: "http://example.org"}).Marshal(expected)
 	assert.NoError(t, err, "function Unmarshal should have returned no error")
 	assert.Equal(t, string(out), string(data), "function Unmarshal should have assigned correct values to the target triple")
+}
+
+func TestMarshalPreservesEmptyTypedLiteralAndUsesPrefixes(t *testing.T) {
+	// Triple with empty typed literal and annotation fields
+	target := []tripleWithAnnotationValues{
+		{
+			Subject:    "http://purl.org/dc/terms/abstract",
+			Predicate:  "http://purl.org/dc/terms/description",
+			Object:     "",
+			DataType:   "qudt:LatexString",
+			ObjectType: "literal",
+		},
+	}
+
+	config := turtle.Config{
+		Prefixes: map[string]string{
+			"dcterms": "http://purl.org/dc/terms/",
+		},
+	}
+
+	out, err := config.Marshal(target)
+	assert.NoError(t, err, "Marshal should not return error")
+
+	assert.Equal(t, `@prefix dcterms: <http://purl.org/dc/terms/> .
+dcterms:abstract dcterms:description ""^^qudt:LatexString .
+`, string(out), "Marshal produced unexpected output")
+
 }

--- a/scanner/sanitize.go
+++ b/scanner/sanitize.go
@@ -17,7 +17,7 @@ var numberRegex = regexp.MustCompile(`^[-0-9]+(?:\.[0-9]+)?`)
 func expandPrefix(token string, value string) string {
 	i := strings.Index(token, ":")
 	if len(token) <= i+1 {
-		return ""
+		return fmt.Sprintf("<%s>", value)
 	} else {
 		if len(token) > i+2 && (token[i+1] == '/' || token[i+1] == '#') && value[len(value)-1] == token[i+1] {
 			// if characters exist for both, trim token since we were going to do that anyway

--- a/scanner/sanitize_test.go
+++ b/scanner/sanitize_test.go
@@ -50,6 +50,22 @@ var sanitizeTestCases = map[string]struct {
 		token: "http://example.org/path",
 		typ:   "iri",
 	},
+	"escaped-quotes": {
+		input: `"a string with escaped \"double quotes\""`,
+		token: `a string with escaped \"double quotes\"`,
+		typ:   "literal",
+	},
+	"single-quote": {
+		input: `"someone's single quote"`,
+		token: `someone's single quote`,
+		typ:   "literal",
+	},
+	"empty-typed-literal": {
+		input:    `""^^qudt:LatexString`,
+		token:    ``,
+		datatype: `qudt:LatexString`,
+		typ:      "literal",
+	},
 }
 
 func TestSanitize(t *testing.T) {

--- a/scanner/scan-turtle.go
+++ b/scanner/scan-turtle.go
@@ -50,9 +50,14 @@ func splitTurtle(data []byte, atEOF bool) (advance int, token []byte, err error)
 		escaped := escapedCharacter(runeBuffer)
 		// if the last characters were literals, switch the multiline
 		// literal and literal state
-		if multilineLiteralEdge {
-			inMultiLineLiteral = !inMultiLineLiteral
-			literal = !literal
+		if multilineLiteralEdge && !escaped {
+			if !inMultiLineLiteral && !literal {
+				inMultiLineLiteral = true
+				literal = true
+			} else if inMultiLineLiteral {
+				inMultiLineLiteral = false
+				literal = false
+			}
 		}
 
 		// if we bump to space character, we return the word, unless there is a literal started
@@ -111,15 +116,25 @@ func splitTurtle(data []byte, atEOF bool) (advance int, token []byte, err error)
 		// if bumbed into quotation mark and not in apostrophe literal,
 		// switch the literal and quotation mark state
 		if r == runeQuotation && !apostrophe && !inMultiLineLiteral && !multilineLiteralEdge && !escaped { // "
-			literal = !literal
-			quotationMark = !quotationMark
+			if !quotationMark && !literal {
+				literal = true
+				quotationMark = true
+			} else if quotationMark {
+				literal = false
+				quotationMark = false
+			}
 		}
 
 		// if bumbed into apostrophe and not in quotation mark literal,
 		// switch the literal state and quotation mark state
 		if r == runeApostrophe && !quotationMark && !inMultiLineLiteral && !multilineLiteralEdge && !escaped { // '
-			literal = !literal
-			apostrophe = !apostrophe
+			if !apostrophe && !literal {
+				literal = true
+				apostrophe = true
+			} else if apostrophe {
+				literal = false
+				apostrophe = false
+			}
 		}
 
 		if len(runeBuffer) == 1 && !literal && !unicode.IsDigit(r) {

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -189,9 +189,13 @@ outer:
 			// check that the field is pointer to string
 			if pointerType.Kind() == reflect.String {
 
-				// omit empty strings
+				// omit empty strings unless it's the object and it has annotations
 				if len(word) == 0 {
-					continue
+					if tag == "object" && (t[label] != "" || t[datatype] != "") {
+						// proceed to set empty string
+					} else {
+						continue
+					}
 				}
 
 				// set value to the pointed string

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -183,3 +183,46 @@ func TestUnmarshalSubjectURLTrailingSlash(t *testing.T) {
 	assert.NoError(t, err, "function Unmarshal should have returned no error")
 	assert.Equal(t, expected, target, "function Unmarshal should have assigned correct values to the target triple")
 }
+
+func TestUnmarshalHandlesEdgeCases(t *testing.T) {
+	rdf := `@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+dcterms:abstract
+  rdfs:isDefinedBy dcterms: ;
+  rdfs:description "a string with escaped \"double quotes\" and someone's single quote in it" ;
+  dcterms:description ""^^qudt:LatexString ;
+.
+`
+
+	var target []tripleWithAnnotationValues
+
+	// Unmarshal the Turtle string
+	err := turtle.Unmarshal([]byte(rdf), &target)
+	assert.NoError(t, err, "Unmarshal should not return error")
+
+	expected := []tripleWithAnnotationValues{
+		{
+			Subject:   "http://purl.org/dc/terms/abstract",
+			Predicate: "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+			Object:    "http://purl.org/dc/terms/", // correctly expanded a CURIE with empty local part
+		},
+		{
+			Subject:   "http://purl.org/dc/terms/abstract",
+			Predicate: "http://www.w3.org/2000/01/rdf-schema#description",
+			Object:    "a string with escaped \\\"double quotes\\\" and someone's single quote in it", // does not stumble on quotes
+		},
+		{
+			Subject:   "http://purl.org/dc/terms/abstract",
+			Predicate: "http://purl.org/dc/terms/description",
+			Object:    "",
+		},
+	}
+
+	assert.Equal(t, len(expected), len(target), "Number of triples should match")
+	for i := range expected {
+		assert.Equal(t, expected[i].Subject, target[i].Subject, "Subject mismatch at index %d", i)
+		assert.Equal(t, expected[i].Predicate, target[i].Predicate, "Predicate mismatch at index %d", i)
+		assert.Equal(t, expected[i].Object, target[i].Object, "Object mismatch at index %d", i)
+	}
+}


### PR DESCRIPTION
This PR fixes several Turtle/RDF edge cases that could previously produce incorrect serialization or incorrect unmarshaling results.

## Fixes included

- Fix marshalling of empty typed literals (preserve ""^^datatype correctly)
- Emit CURIEs when prefix mappings are provided in options/config
- Fix parsing of multiline string literals that contain quote characters
- Fix CURIE expansion on unmarshal when the local part is empty (e.g. prefix:)